### PR TITLE
[chore] 개별 뉴스기사 조회, 스크랩, 언론사 구독 - userId를 토큰에서 받아오는 것으로 변경하기

### DIFF
--- a/src/main/java/com/umc/NewTine/controller/NewsController.java
+++ b/src/main/java/com/umc/NewTine/controller/NewsController.java
@@ -38,10 +38,14 @@ public class NewsController {
 
     //개별 뉴스기사
     @GetMapping("news/{newsId}")
-    public BaseResponse<SingleNewsResponseDto> getSingleNews(@PathVariable("newsId") Long newsId) {
-        //userId 수정하기
-        Long userId = 1L;
+    public BaseResponse<SingleNewsResponseDto> getSingleNews(@AuthenticationPrincipal User user, @PathVariable("newsId") Long newsId) {
         try {
+            //userId 기본값(사용자가 로그인을 하지 않은 경우) - null
+            Long userId = null;
+            //사용자가 로그인을 한 경우 - user에서 userId 가져오기
+            if (user!=null) {
+                userId = user.getId();
+            }
             return new BaseResponse<>(newsService.getSingleNewsById(userId, newsId));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -103,10 +107,9 @@ public class NewsController {
 
     //스크랩한 뉴스 조회
     @GetMapping("/news/scrap")
-    public BaseResponse<List<ScrapNewsResponseDto>> getScrappedNews() {
-        //userId 수정하기
-        Long userId = 1L;
+    public BaseResponse<List<ScrapNewsResponseDto>> getScrappedNews(@AuthenticationPrincipal User user) {
         try {
+            Long userId=user.getId();
             return new BaseResponse<>(newsService.getScrappedNews(userId));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -116,10 +119,9 @@ public class NewsController {
 
     //뉴스 스크랩하기
     @PostMapping("/news/scrap/{newsId}")
-    public BaseResponse<Void> scrapNews(@PathVariable("newsId") Long newsId) {
-        //userId 수정하기
-        Long userId = 1L;
+    public BaseResponse<Void> scrapNews(@AuthenticationPrincipal User user,@PathVariable("newsId") Long newsId) {
         try {
+            Long userId=user.getId();
             if (newsService.saveNewsScrap(userId, newsId)) {
                 return new BaseResponse<>(true, HttpStatus.OK.value(), "Success");
             } else {
@@ -132,9 +134,9 @@ public class NewsController {
 
     //뉴스기사 스크랩 취소하기
     @DeleteMapping("/news/scrap/{newsId}")
-    public BaseResponse<Void> cancelScrapNews(@PathVariable("newsId") Long newsId) {
-        Long userId = 1L; // 사용자 ID 수정하기
+    public BaseResponse<Void> cancelScrapNews(@AuthenticationPrincipal User user,@PathVariable("newsId") Long newsId) {
         try {
+            Long userId=user.getId();
             if (newsService.deleteNewsScrap(userId, newsId)) {
                 return new BaseResponse<>(true, HttpStatus.OK.value(), "Success");
             } else {

--- a/src/main/java/com/umc/NewTine/controller/PressController.java
+++ b/src/main/java/com/umc/NewTine/controller/PressController.java
@@ -1,10 +1,12 @@
 package com.umc.NewTine.controller;
 
+import com.umc.NewTine.domain.User;
 import com.umc.NewTine.dto.response.BaseException;
 import com.umc.NewTine.dto.response.BaseResponse;
 import com.umc.NewTine.service.PressService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,12 +20,11 @@ public class PressController {
         this.pressService = pressService;
     }
 
-    //뉴스 스크랩하기
-    @PostMapping("/press{pressId}")
-    public BaseResponse<Void> subscribePress(@PathVariable("pressId") Long pressId){
-        //userId 수정하기
-        Long userId=1L;
+    //언론사 구독하기
+    @PostMapping("/press/{pressId}")
+    public BaseResponse<Void> subscribePress(@AuthenticationPrincipal User user, @PathVariable("pressId") Long pressId){
         try{
+            Long userId=user.getId();
             if (pressService.savePressSubscription(userId,pressId)){
                 return new BaseResponse<>(true, HttpStatus.OK.value(),"Success");
             } else{
@@ -34,11 +35,11 @@ public class PressController {
         }
     }
 
-    //뉴스기사 스크랩 취소하기
-    @DeleteMapping("/press{pressId}")
-    public BaseResponse<Void> cancelSubscribePress(@PathVariable("pressId") Long pressId){
-        Long userId = 1L; // userId 수정하기
+    //언론사 구독 취소하기
+    @DeleteMapping("/press/{pressId}")
+    public BaseResponse<Void> cancelSubscribePress(@AuthenticationPrincipal User user,@PathVariable("pressId") Long pressId){
         try {
+            Long userId=user.getId();
             if (pressService.deletePressSubscription(userId, pressId)) {
                 return new BaseResponse<>(true,HttpStatus.OK.value(),"Success");
             } else{

--- a/src/main/java/com/umc/NewTine/service/NewsService.java
+++ b/src/main/java/com/umc/NewTine/service/NewsService.java
@@ -55,8 +55,13 @@ public class NewsService {
                 .orElseThrow(() -> new EntityNotFoundException("News not found with ID: " + newsId));
 
         Press press = news.getPress();
-        boolean scrapped = newsScrapRepository.existsByNewsIdAndUserId(newsId, userId);
-        boolean subscribed = pressSubscriptionRepository.existsByPressIdAndUserId(press.getId(), userId);
+        boolean scrapped = false;
+        boolean subscribed = false;
+
+        if(userId!=null){
+            scrapped = newsScrapRepository.existsByNewsIdAndUserId(newsId, userId);
+            subscribed = pressSubscriptionRepository.existsByPressIdAndUserId(press.getId(), userId);
+        }
 
         List<NewsAndCategory> newsAndCategoryList = newsAndCategoryRepository.findByNewsId(newsId);
         List<String> category = newsAndCategoryList.stream()


### PR DESCRIPTION
## 💡 제목
개별 뉴스기사 조회, 스크랩, 언론사 구독 - userId를 토큰에서 받아오는 것으로 변경하기

## ✨작업 내용
1. userId를 토큰에서 받아오는 것으로 수정
2. 개별 뉴스기사 조회 api에서 사용자가 로그인을 하지 않은 경우와 한 경우를 나눔 

## 📷 스크린샷
<!-- 스크린샷이 필요하면 첨부해주세요(선택) -->
<br><br>

## 👀 참고사항
<!-- 참고할 사항이 있다면 적어주세요 (선택)-->
<br><br>

Close #37 
