### PR TITLE
[refactor] 뉴스-카테고리 엔티티 1대1 관계로 변경

### DIFF
--- a/src/main/java/com/umc/NewTine/domain/NewsAndCategory.java
+++ b/src/main/java/com/umc/NewTine/domain/NewsAndCategory.java
@@ -17,11 +17,11 @@ public class NewsAndCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id = null;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="category_id")
     private NewsCategory newsCategory;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="news_id")
     private News news;
 }

--- a/src/main/java/com/umc/NewTine/dto/request/SignupRequestDto.java
+++ b/src/main/java/com/umc/NewTine/dto/request/SignupRequestDto.java
@@ -12,12 +12,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SignupRequestDto {
     private String email;
     private String password;
+    private String nickname;
+    private String name;
 
 
     @Builder
     public SignupRequestDto(User user) {
         this.email = user.getEmail();
         this.password = user.getPassword();
+        this.nickname = user.getNickname();
+        this.name = user.getName();
     }
 
     public void encryptPassword(PasswordEncoder passwordEncoder) {
@@ -32,6 +36,8 @@ public class SignupRequestDto {
         return User.builder()
                 .email(signupRequestDto.getEmail())
                 .password(signupRequestDto.getPassword())
+                .nickname(signupRequestDto.getNickname())
+                .name(signupRequestDto.getName())
                 .build();
     }
 }

--- a/src/main/java/com/umc/NewTine/dto/response/SingleNewsResponseDto.java
+++ b/src/main/java/com/umc/NewTine/dto/response/SingleNewsResponseDto.java
@@ -19,13 +19,13 @@ public class SingleNewsResponseDto {
     private int pressSubscriber;
     private boolean subscribed;
     private boolean scrapped;
-    private List<String> category;
+    private String category;
     private List<String> successMission;
     private String newsImg;
     private Long newsId;
 
     public SingleNewsResponseDto(String title, String content, String createdAt, String pressName,
-                                 String pressImage, int pressSubscriber, boolean subscribed, boolean scrapped, List<String> category,
+                                 String pressImage, int pressSubscriber, boolean subscribed, boolean scrapped, String category,
                                  List<String> successMission, String newsImg, Long newsId) {
         this.title=title;
         this.content=content;

--- a/src/main/java/com/umc/NewTine/repository/NewsAndCategoryRepository.java
+++ b/src/main/java/com/umc/NewTine/repository/NewsAndCategoryRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface NewsAndCategoryRepository extends JpaRepository<NewsAndCategory,Long> {
-    List<NewsAndCategory> findByNewsId(Long newsId);
+    NewsAndCategory findByNewsId(Long newsId);
 
     @Query("SELECT nc.news FROM NewsAndCategory nc WHERE nc.newsCategory.id = :categoryId")
     Optional<List<News>> findNewsByCategoryId(@Param("categoryId") Long categoryId);

--- a/src/main/java/com/umc/NewTine/service/NewsService.java
+++ b/src/main/java/com/umc/NewTine/service/NewsService.java
@@ -65,16 +65,19 @@ public class NewsService {
             scrapped = newsScrapRepository.existsByNewsIdAndUserId(newsId, userId);
             subscribed = pressSubscriptionRepository.existsByPressIdAndUserId(press.getId(), userId);
         }
-//        newsAndCategoryRepository.findCategoryIdByNewsId(newsId)
 
-        List<NewsAndCategory> newsAndCategoryList = newsAndCategoryRepository.findByNewsId(newsId);
-        List<String> category = newsAndCategoryList.stream()
-                .map(data -> newsCategoryRepository.getById(data.getNewsCategory().getId()).getName())
-                .collect(Collectors.toList());
+        NewsAndCategory newsAndCategory = newsAndCategoryRepository.findByNewsId(newsId);
+        String category = newsAndCategory.getNewsCategory().getName();
 
         if (!missionRecordRepository.existsByUserAndMissionId(user, 1)) {
             missionRecordRepository.save(new MissionRecord(user, 1));
             missionRecordRepository.findSuccessDailyMissionByUser(user);
+        }
+
+        String createdAtFormatted = "null";
+        LocalDateTime createdAt = news.getCreatedAt();
+        if (createdAt != null) {
+            createdAtFormatted = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm").format(createdAt);
         }
 
 
@@ -82,7 +85,7 @@ public class NewsService {
         return SingleNewsResponseDto.builder()
                 .title(news.getTitle())
                 .content(news.getContent())
-                .createdAt(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm").format(news.getCreatedAt()))
+                .createdAt(createdAtFormatted)
                 .pressName(press.getName())
                 .pressImage(press.getImage())
                 .pressSubscriber(press.getSubscriber())


### PR DESCRIPTION
## 💡 제목
[refactor] 뉴스-카테고리 엔티티 1대1 관계로 변경

## ✨작업 내용
뉴스, 카테고리 엔티티 관계를 1대1 관계로 변경한다.

## 📷 스크린샷
<!-- 스크린샷이 필요하면 첨부해주세요(선택) -->

## 👀 참고사항
<!-- 참고할 사항이 있다면 적어주세요 (선택)-->

Close #이슈번호
